### PR TITLE
feat: add clipboard, esc, and fullscreen as shell defaults

### DIFF
--- a/clipboard/clipboard.go
+++ b/clipboard/clipboard.go
@@ -1,0 +1,26 @@
+package clipboard
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// CopyToClipboard copies text to the system clipboard.
+func CopyToClipboard(text string) {
+	var cmd *exec.Cmd
+
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("pbcopy")
+	case "linux":
+		cmd = exec.Command("xclip", "-selection", "clipboard")
+	case "windows":
+		cmd = exec.Command("clip")
+	default:
+		return
+	}
+
+	cmd.Stdin = strings.NewReader(text)
+	_ = cmd.Run()
+}

--- a/keys.go
+++ b/keys.go
@@ -7,17 +7,19 @@ import (
 
 // GlobalKeyMap defines the keybindings available in all panels.
 type GlobalKeyMap struct {
-	Help            key.Binding
-	Quit            key.Binding
-	ThrowError      key.Binding
-	MockFetch       key.Binding
-	ToggleLeftPanel key.Binding
-	OpenModal       key.Binding
+	Help             key.Binding
+	Quit             key.Binding
+	ThrowError       key.Binding
+	MockFetch        key.Binding
+	ToggleLeftPanel  key.Binding
+	OpenModal        key.Binding
+	CloseRightPanel  key.Binding
+	ToggleFullscreen key.Binding
 }
 
 // CommonKeys are the keybindings shown in every panel's help.
 var CommonKeys = []key.Binding{
-	GlobalKeys(false).ToggleLeftPanel, GlobalKeys(false).OpenModal, GlobalKeys(false).Help, GlobalKeys(false).Quit,
+	GlobalKeys(false).ToggleLeftPanel, GlobalKeys(false).OpenModal, GlobalKeys(false).CloseRightPanel, GlobalKeys(false).ToggleFullscreen, GlobalKeys(false).Help, GlobalKeys(false).Quit,
 }
 
 // DevKeys are additional keybindings shown in dev mode.
@@ -59,6 +61,14 @@ func GlobalKeys(devMode bool) GlobalKeyMap {
 		OpenModal: key.NewBinding(
 			key.WithKeys("@"),
 			key.WithHelp("@", "open full message modal"),
+		),
+		CloseRightPanel: key.NewBinding(
+			key.WithKeys("esc"),
+			key.WithHelp("esc", "close panel"),
+		),
+		ToggleFullscreen: key.NewBinding(
+			key.WithKeys("f"),
+			key.WithHelp("f", "fullscreen"),
 		),
 	}
 

--- a/shell/update.go
+++ b/shell/update.go
@@ -8,6 +8,7 @@ import (
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
 	"github.com/felipeospina21/tuishell"
+	"github.com/felipeospina21/tuishell/clipboard"
 	"github.com/felipeospina21/tuishell/statusline"
 	"github.com/felipeospina21/tuishell/style"
 )
@@ -75,7 +76,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 		m.Ctx.FocusedPanel = m.prevFocus
 
 	case tuishell.CopyModalMsg:
-		// Apps handle clipboard — forwarded via returned cmd
+		clipboard.CopyToClipboard(m.Modal.Content)
 
 	case tuishell.ResetHighlightMsg:
 		m.Modal.Highlight = false
@@ -88,6 +89,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tuishell.OpenRightPanelMsg:
 		if !m.isRightOpen {
 			m.isRightOpen = true
+			m.Ctx.FocusedPanel = tuishell.RightPanel
 			m.recomputeLayout()
 			cmds = append(cmds, m.pushSizeToPanels()...)
 		}
@@ -104,6 +106,7 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	case tuishell.CloseRightPanelMsg:
 		m.isRightOpen = false
 		m.isRightFullscreen = false
+		m.Ctx.FocusedPanel = tuishell.MainPanel
 		m.recomputeLayout()
 		cmds = append(cmds, m.pushSizeToPanels()...)
 
@@ -199,6 +202,20 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 	switch {
 	case match(gk.Quit):
 		return m, tea.Quit, true
+
+	case m.isRightOpen && match(gk.CloseRightPanel):
+		m.isRightOpen = false
+		m.isRightFullscreen = false
+		m.Ctx.FocusedPanel = tuishell.MainPanel
+		m.recomputeLayout()
+		cmds := m.pushSizeToPanels()
+		return m, tea.Batch(cmds...), true
+
+	case m.isRightOpen && match(gk.ToggleFullscreen):
+		m.isRightFullscreen = !m.isRightFullscreen
+		m.recomputeLayout()
+		cmds := m.pushSizeToPanels()
+		return m, tea.Batch(cmds...), true
 
 	case match(gk.ToggleLeftPanel):
 		m.isLeftOpen = !m.isLeftOpen


### PR DESCRIPTION
## Summary

Move common right-panel behaviors into tuishell so all consumers get them for free:

- **Clipboard**: New `clipboard/` package. Shell handles `CopyModalMsg` directly.
- **Close right panel**: `esc` is now a global key when right panel is open.
- **Toggle fullscreen**: `f` is now a global key when right panel is open.
- **Focus management**: `OpenRightPanelMsg` sets focus to right panel, `CloseRightPanelMsg` resets to main.

## What was tested

- `GOWORK=off go build ./...` and `go test ./...` pass
- Verified mrglab and jiraf build with these changes via go.work