### PR TITLE
fix: move fullscreen toggle from global keys to right panel

### DIFF
--- a/keys.go
+++ b/keys.go
@@ -7,19 +7,18 @@ import (
 
 // GlobalKeyMap defines the keybindings available in all panels.
 type GlobalKeyMap struct {
-	Help             key.Binding
-	Quit             key.Binding
-	ThrowError       key.Binding
-	MockFetch        key.Binding
-	ToggleLeftPanel  key.Binding
-	OpenModal        key.Binding
-	CloseRightPanel  key.Binding
-	ToggleFullscreen key.Binding
+	Help            key.Binding
+	Quit            key.Binding
+	ThrowError      key.Binding
+	MockFetch       key.Binding
+	ToggleLeftPanel key.Binding
+	OpenModal       key.Binding
+	CloseRightPanel key.Binding
 }
 
 // CommonKeys are the keybindings shown in every panel's help.
 var CommonKeys = []key.Binding{
-	GlobalKeys(false).ToggleLeftPanel, GlobalKeys(false).OpenModal, GlobalKeys(false).CloseRightPanel, GlobalKeys(false).ToggleFullscreen, GlobalKeys(false).Help, GlobalKeys(false).Quit,
+	GlobalKeys(false).ToggleLeftPanel, GlobalKeys(false).OpenModal, GlobalKeys(false).CloseRightPanel, GlobalKeys(false).Help, GlobalKeys(false).Quit,
 }
 
 // DevKeys are additional keybindings shown in dev mode.
@@ -65,10 +64,6 @@ func GlobalKeys(devMode bool) GlobalKeyMap {
 		CloseRightPanel: key.NewBinding(
 			key.WithKeys("esc"),
 			key.WithHelp("esc", "close panel"),
-		),
-		ToggleFullscreen: key.NewBinding(
-			key.WithKeys("f"),
-			key.WithHelp("f", "fullscreen"),
 		),
 	}
 

--- a/shell/update.go
+++ b/shell/update.go
@@ -211,12 +211,6 @@ func (m Model) handleGlobalKeys(msg tea.KeyPressMsg) (Model, tea.Cmd, bool) {
 		cmds := m.pushSizeToPanels()
 		return m, tea.Batch(cmds...), true
 
-	case m.isRightOpen && match(gk.ToggleFullscreen):
-		m.isRightFullscreen = !m.isRightFullscreen
-		m.recomputeLayout()
-		cmds := m.pushSizeToPanels()
-		return m, tea.Batch(cmds...), true
-
 	case match(gk.ToggleLeftPanel):
 		m.isLeftOpen = !m.isLeftOpen
 		if m.isRightOpen {

--- a/table/table.go
+++ b/table/table.go
@@ -89,8 +89,8 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("b/pgup", "page up"),
 		),
 		PageDown: key.NewBinding(
-			key.WithKeys("f", "pgdown", spacebar),
-			key.WithHelp("f/pgdn", "page down"),
+			key.WithKeys("pgdown", spacebar),
+			key.WithHelp("pgdn", "page down"),
 		),
 		HalfPageUp: key.NewBinding(
 			key.WithKeys("u", "ctrl+u"),


### PR DESCRIPTION
## Changes

- Removed `ToggleFullscreen` from `GlobalKeyMap` and `CommonKeys`
- Removed `f` key handler from `handleGlobalKeys` in shell
- Removed `f` from table `PageDown` keybinding (was conflicting)
- `ToggleFullscreenMsg` and its handler in shell `Update` are preserved — consumers emit it from their right panel components

## Why

`f` was a global key, which meant it was intercepted before reaching the focused panel. This caused conflicts with table page-down and consumer-specific `f` bindings (e.g. mrglab's pipeline filter). Fullscreen only applies to the right panel, so it belongs there.